### PR TITLE
Add help descriptions and refactor banner handling

### DIFF
--- a/RFDump/Command/DumpCommand.cs
+++ b/RFDump/Command/DumpCommand.cs
@@ -11,7 +11,7 @@ public class DumpCommand(SerialService serialService)
 {
     private readonly SerialService _serialService = serialService;
 
-    [Command("dump")]
+    [Command("dump", help: "Dump firmware from connected serial device")]
     public async Task Dump(string? port = null, int baudRate = 115200, string filename = "firmware.bin", uint chunkSize = 0x4000)
     {
         DumpConfiguration? dumpConfig = port == null

--- a/RFDump/Command/PortCommand.cs
+++ b/RFDump/Command/PortCommand.cs
@@ -14,7 +14,7 @@ namespace RFDump.Command
     {
         private readonly SerialService _serialService = serialService;
 
-        [Command("ports")]
+        [Command("ports", help: "List all detected serial ports")]
         public string Ports()
         {
             var ports = _serialService.GetPorts();

--- a/RFDump/Configure.cs
+++ b/RFDump/Configure.cs
@@ -1,10 +1,10 @@
 ﻿using System.IO.Ports;
-using System.Reflection;
-using System.Resources;
+using System.Text;
 
 using RFDump.Service;
 
 using Spectre.Console;
+using Spectre.Console.Rendering;
 
 namespace RFDump;
 
@@ -14,8 +14,7 @@ internal static class Configure
 {
     public static DumpConfiguration AskForDumpConfiguration(SerialService serialService)
     {
-        var font = GetFigletFont("miniFont");
-        AnsiConsole.Write(new FigletText(font, "RFDump"));
+        PrintBanner();
         AnsiConsole.MarkupLine("[cyan]Firmware dump configuration[/]");
         var filename = AnsiConsole.Prompt(new TextPrompt<string>("Enter filename for dump")
             .DefaultValue("firmware.bin"));
@@ -50,11 +49,17 @@ internal static class Configure
         return new DumpConfiguration(filename, new SerialConfiguration(port, baudRate, 8, Parity.None, StopBits.One));
     }
 
-    private static FigletFont GetFigletFont(string name)
+    internal static FigletFont GetFigletFont()
     {
         var font = RFDump.FigletFont;
 
         return FigletFont.Parse(font);
     }
 
+    internal static void PrintBanner()
+    {
+        var font = GetFigletFont();
+        var banner = new FigletText(font, "RFDump");
+        AnsiConsole.Write(banner);
+    }
 }

--- a/RFDump/Program.cs
+++ b/RFDump/Program.cs
@@ -1,10 +1,19 @@
 ﻿
 using Microsoft.Extensions.DependencyInjection;
+
 using QuiCLI;
+
+using RFDump;
 using RFDump.Command;
 using RFDump.Service;
 
 var builder = QuicApp.CreateBuilder();
+builder.Configure(config => config.CustomBanner = () =>
+{
+    Configure.PrintBanner();
+    return string.Empty;
+});
+
 builder.Services.AddTransient<SerialService>();
 var app = builder.Build();
 

--- a/RFDump/RFDump.csproj
+++ b/RFDump/RFDump.csproj
@@ -8,11 +8,12 @@
     <PublishAot>true</PublishAot>
     <PublishTrimmed>True</PublishTrimmed>
     <InvariantGlobalization>true</InvariantGlobalization>
+    <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
     <AssemblyName>rfdump</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="QuiCLI" Version="0.3.2" />
+    <PackageReference Include="QuiCLI" Version="0.3.3" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
   </ItemGroup>
@@ -23,21 +24,6 @@
 
   <ItemGroup>
     <None Include="D:\RFDump\RFDump\.editorconfig" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Update="RFDump.Designer.cs">
-      <DesignTime>True</DesignTime>
-      <AutoGen>True</AutoGen>
-      <DependentUpon>RFDump.resx</DependentUpon>
-    </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <EmbeddedResource Update="RFDump.resx">
-      <Generator>ResXFileCodeGenerator</Generator>
-      <LastGenOutput>RFDump.Designer.cs</LastGenOutput>
-    </EmbeddedResource>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Updated `DumpCommand` and `PortCommand` to include help descriptions.
- Cleaned up `Configure.cs` by removing unused `using` directives and adding necessary ones.
- Refactored `AskForDumpConfiguration` to use a new `PrintBanner` method.
- Added `PrintBanner` method in `Configure.cs` for banner printing with `Spectre.Console`.
- Made `GetFigletFont` method internal and parameterless.
- Configured `Program.cs` to use the new `PrintBanner` method.
- Updated `RFDump.csproj` to enable trim analyzer and upgraded `QuiCLI` package to `0.3.3`.
- Removed unnecessary design-time and embedded resource configurations from `RFDump.csproj`.