### PR TITLE
Update QuiCLI package to version 0.3.4

### DIFF
--- a/RFDump/RFDump.csproj
+++ b/RFDump/RFDump.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="QuiCLI" Version="0.3.3" />
+    <PackageReference Include="QuiCLI" Version="0.3.4" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
The `QuiCLI` package reference in the `RFDump.csproj` file has been updated from version `0.3.3` to version `0.3.4`. This change ensures the project uses the latest version of the `QuiCLI` library.