### PR TITLE
Update QuiCLI package version in RFDump.csproj

### DIFF
--- a/RFDump/RFDump.csproj
+++ b/RFDump/RFDump.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="QuiCLI" Version="0.3.4" />
+    <PackageReference Include="QuiCLI" Version="0.3.5" />
     <PackageReference Include="Spectre.Console" Version="0.49.1" />
     <PackageReference Include="System.IO.Ports" Version="8.0.0" />
   </ItemGroup>


### PR DESCRIPTION
Updated the `QuiCLI` package version from `0.3.4` to `0.3.5` in the `RFDump.csproj` file to ensure compatibility with the latest features and bug fixes.